### PR TITLE
Fix tool-script naming for 3 or more DB instance sets

### DIFF
--- a/pg_rep_test
+++ b/pg_rep_test
@@ -1231,8 +1231,8 @@ file_body=$(cat <<-'TOOL_FILE'
 TOOL_FILE
 )
 
-  local IFS=""
-  while [[ $(ls -A "tool${subset:+'_'$subset}.pg_rep_test" 2> /dev/null) ]]
+  unset IFS
+  while [[ $(ls -A "tool${subset:+_$subset}.pg_rep_test" 2> /dev/null) ]]
   do
     ((subset++))
   done


### PR DESCRIPTION
Unset IFS, so that Bash uses the default setting.

Remove quotes around the underscore to eliminate error.

Without these fixes the tool_1.pg_rep_test is repeatedly overwritten
instead of using numbers higher than 1.